### PR TITLE
React用のDocker設定を追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,21 @@ services:
     volumes:
       - ./db/data:/var/lib/mysql
       - ./db/conf.d/my.cnf:/etc/mysql/conf.d/my.cnf
-    restart: 'always'
+    restart: always
+    networks:
+      - pokemon_manager
+
+  frontend:
+    container_name: pokemon_frontend
+    build:
+      context: ./frontend
+    volumes:
+      - ./frontend:/var/www/frontend
+      - /var/www/frontend/node_modules
+    ports:
+      - 3000:3000
+    restart: always
+    tty: true
     networks:
       - pokemon_manager
 

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:10.15.3-alpine
+
+WORKDIR /var/www/frontend
+
+ENV PATH /app/node_modules/.bin:$PATH
+
+COPY package.json package-lock.json ./
+
+RUN npm install
+
+COPY . ./
+
+CMD ["npm", "start"]


### PR DESCRIPTION
- docker-composeでReact コンテナを動かすよう修正
  - React-Scriptsのバージョン次第でコンテナが立ち上がらない事象に嵌る(https://github.com/facebook/create-react-app/issues/8688)
    - `tty: true`を追加で動く模様